### PR TITLE
issue-35-extend-the-save-versioned-pickle-file-function-so-it-creates-a-data-version-lineage-text-file

### DIFF
--- a/src/ml_resources/data/pickle_utility.py
+++ b/src/ml_resources/data/pickle_utility.py
@@ -2,7 +2,7 @@ import pickle
 from pathlib import Path
 import re
 
-def save_versioned_pickle_file(obj, object_name, folder='.'):
+def save_versioned_pickle_file(obj, object_name, folder='.', comments="New version of file."):
     """
     Saves `obj` into a versioned Pickle file in `folder`.
     
@@ -10,7 +10,10 @@ def save_versioned_pickle_file(obj, object_name, folder='.'):
     
     Otherwise the function creates {object_name}_{max_version+1}.pickle.
     """
-    folder_path = Path(folder)
+    folder_path = Path(f"{folder}/{object_name}/")
+    #file_path.parent.mkdir(parents=True, exist_ok=True)
+    folder_path.mkdir(parents=True, exist_ok=True)
+    #folder_path = Path(folder)
     # Pattern to match files like object_name_3.pickle
     pattern = re.compile(rf"^{re.escape(object_name)}_(\d+)\.pickle$")
     max_version = 0
@@ -22,9 +25,18 @@ def save_versioned_pickle_file(obj, object_name, folder='.'):
                 max_version = max(max_version, version)
     new_version = max_version + 1
     # Write object to Pickle file
-    print(f"{folder}/{object_name}_{new_version}.pickle")
-    with open(f"{folder}/{object_name}_{new_version}.pickle", 'wb') as handle:
+    file_path = Path(f"{folder}/{object_name}/{object_name}_{new_version}.pickle")
+    print(file_path)
+    with open(file_path, 'wb') as handle:
         pickle.dump(obj, handle, protocol=pickle.HIGHEST_PROTOCOL)
+    generate_data_versioning_document(f"{folder}/{object_name}", object_name, new_version, comments)
+
+def generate_data_versioning_document(data_documentation_folder,
+    dataset_name,
+    version_number,
+    version_comments):
+    with open(f"{data_documentation_folder}/{dataset_name}_notes_{version_number}.txt", "w") as f:
+        f.write(version_comments)
 
 def read_dataset_from_file(filename):
     data_file = open(filename, 'rb')


### PR DESCRIPTION
Added function for creating a version metadata file when saving a new version of a dataset. Deals with https://github.com/CLOSER-Cohorts/ml-resources/issues/35