### PR TITLE
issue-95-write-code-for-getting-information-needed-to-detect-data-drift

### DIFF
--- a/projects/am2_project/am2_project.py
+++ b/projects/am2_project/am2_project.py
@@ -8,9 +8,10 @@ import pandas as pd
 from src.ml_resources import (
     read_dataset_from_file,
     save_versioned_pickle_file,
-    obtain_items_from_colectica
+    obtain_items_from_colectica,
     get_all_sweeps,
-    get_max_file_version)
+    get_max_file_version,
+    get_summary_data)
 from projects.am2_project.src.data.utility import (
         create_am2_input_features,
         train_semi_supervised_model
@@ -118,11 +119,12 @@ train_semi_supervised_model(
     generate_classification_report=True,
     save_model_in_package_file=True,
     all_models=all_item_models)
-# dtc was fitted in train_semi_supervised_model so the below check_is_fitted command should
-# run and not throw an error.
-check_is_fitted(dtc)
-save_versioned_pickle_file(all_am2_relationships_data,
-        'all_am2_relationships_data', folder='./projects/am2_project/data')
+
+# The get_summary_data command is used to check in older versions of the pickles for summary
+# stats (note that folder and object_name should be defined as above)
+
+get_summary_data(Path(f"{folder}"), object_name)
+
 
 all_labelled_data=read_dataset_from_file('projects/am2_project/data/human_labelled_data/all_human_labelled_data_4.pickle')
 all_relationships=read_dataset_from_file('projects/am2_project/data/all_am2_relationships_data/all_am2_relationships_data_88.pickle')

--- a/projects/am2_project/src/check_for_data.py
+++ b/projects/am2_project/src/check_for_data.py
@@ -67,7 +67,6 @@ def main(args):
         logging.info(f"Running task with param: {args.param}")
         with open("./projects/am2_project/config/am2_config.json") as f:
             project_config = json.load(f)
-        """    
         results = check_for_newly_available_data(project_config)
         if len(results['new_item_urns'])>0:
             items = [create_item_object(x) for x in results['new_item_urns']][0:500]
@@ -97,7 +96,6 @@ def main(args):
                 'am2_relationships_data_for_future_model',
                 folder='./projects/am2_project/data/pending_training_data',
                 )
-        """
         
         all_sweeps=get_all_sweeps()
         sweeps_not_in_project=check_for_new_sweeps(project_config, all_sweeps)

--- a/src/ml_resources/data/pickle_utility.py
+++ b/src/ml_resources/data/pickle_utility.py
@@ -45,3 +45,16 @@ def read_dataset_from_file(filename):
     data_file = open(filename, 'rb')
     model_data = pickle.load(data_file)
     return model_data
+
+def get_summary_data(folder_path, object_name):
+    pattern = re.compile(rf"^{re.escape(object_name)}_(\d+)\.pickle$")
+    for file in folder_path.iterdir():
+        if file.is_file():
+            match = pattern.match(file.name)
+            if match:
+                file_path = Path(f"{folder_path}/{file.name}")
+                all_item_models=read_dataset_from_file(file_path)
+                for classifier_type in all_item_models.keys():
+                    print(f"Classifier: {classifier_type}")
+                    print(f"File name: {file.name}")
+                    print(all_item_models[classifier_type]['data'][['x', 'y', 'DistanceFromOrigin', 'AnomalyScore']].describe())


### PR DESCRIPTION
Add code to get summary statistics for monitoring from model data/metadata stored in pickle files. Deals with https://github.com/CLOSER-Cohorts/ml-resources/issues/94