### PR TITLE
issue-121-add-extra-logging-statements-to-am2-to-clarify-start-end-of-pipeline-operations

### DIFF
--- a/projects/am2_project/src/check_for_data.py
+++ b/projects/am2_project/src/check_for_data.py
@@ -61,7 +61,9 @@ def check_for_new_sweeps(project_config, all_sweeps):
     return sweeps_not_in_project
 
 def main(args):
-    logger.info(StructuredMessage(description='Checking for newly available data in Colectica repository'))
+    logger.info(StructuredMessage(description='Checking for newly available data in Colectica repository'),
+        operation_type="data_check_start",
+        )
     start_time_for_input_creation=datetime.now()
     try:
         from src.slack.utility import send_message_to_slack
@@ -88,9 +90,10 @@ def main(args):
         all_item_models=read_dataset_from_file(file_path)
 
         # Your core logic here
-        logging.info(StructuredMessage(description="Creating input features..."))
+        #logging.info(StructuredMessage(description="Creating input features..."))
         with open("./projects/am2_project/config/am2_config.json") as f:
             project_config = json.load(f)
+        # Check for new data...    
         results = check_for_newly_available_data(project_config)
         if len(results['new_item_urns'])>0:
             items = [create_item_object(x) for x in results['new_item_urns']][0:1000]
@@ -101,10 +104,14 @@ def main(args):
                 items_of_a_type = [x for x in items 
                     if x['ItemType']==colectica_client.item_code(item_type)]
                 start_time_for_input_feature=datetime.now()
+                # Create new input features...
+                logger.info(StructuredMessage(message=f"Creating input features...",
+                    operation_type="input_feature_creation_start",
+                    status="Pending"))
                 new_am2_relationships_data_single_type=create_am2_input_features(items_of_a_type, colectica_client)
                 duration_input_creation=datetime.now()-start_time_for_input_feature
                 logger.info(StructuredMessage(description=f"Time for input creation for {len(items_of_a_type)} items of type {item_type}",
-                    operation_type=f"input feature creation",
+                    operation_type=f"input feature creation_end",
                     item_type=item_type,
                     number_of_records=len(items_of_a_type),
                     status="Success",
@@ -114,12 +121,17 @@ def main(args):
                     order=list(all_item_models['Category_classifier_for_error_detection']['model'].feature_names_in_)
                     new_am2_relationships_data_single_type=new_am2_relationships_data_single_type.reindex(
                         columns=order).replace({np.nan: 0}) 
+                    # Make predictions on new data...
                     start_time_for_model_predictions=datetime.now()
+                    logger.info(StructuredMessage(message=f"Making predictions on data...",
+                        operation_type="predictions_start",
+                        status="Pending"))
                     predictions=all_item_models['Category_classifier_for_error_detection']['model'].predict(
                         new_am2_relationships_data_single_type
                         )
                     duration_model_prediction=datetime.now()-start_time_for_model_predictions
                     logger.info(StructuredMessage(description=f"Time for AM2 model predictions for {len(new_am2_relationships_data_single_type)} items of type {item_type}",
+                        operation_type="predictions_start",
                         status="Success",
                         duration=duration_model_prediction.seconds))
                     indices_flagged = [i for i, x in enumerate(predictions) if x == -1]    
@@ -127,8 +139,13 @@ def main(args):
                     if len(anomalies)>0:
                         print("ANOMALIES PREDICTED")
                         print(anomalies)
+                        logger.info(StructuredMessage(description=f"{len(anomalies)} anomalies detected for items of type {item_type}",
+                        operation_type="anomalies_detected",
+                        number_number_of_anomalies=len(anomalies),
+                        item_type=item_type))
                         #send_message_to_slack(str(anomalies))
                 all_new_am2_relationships_data[item_type]=new_am2_relationships_data_single_type
+            # Save data we just retrieved for use in training a new model
             save_versioned_pickle_file(
                 all_new_am2_relationships_data,
                 'am2_relationships_data_for_future_model',
@@ -137,8 +154,8 @@ def main(args):
         duration_input_creation=datetime.now()-start_time_for_input_creation
         logger.info(StructuredMessage(description="Time for entire data check process",
             status="Success",
+            operation_type="data_check_end",
             duration=duration_input_creation.seconds))
-        
         all_sweeps=get_all_sweeps()
         sweeps_not_in_project=check_for_new_sweeps(project_config, all_sweeps)
         if len(sweeps_not_in_project)>0:

--- a/projects/am2_project/src/data/utility.py
+++ b/projects/am2_project/src/data/utility.py
@@ -296,7 +296,7 @@ def check_for_newly_available_data(project_config):
         for item_type, model in all_models.items():
             all_urns_in_current_dataset.extend(model['metadata']["training_item_ids"])
     except Exception as e:
-        raise FileNotFoundError(f"File not found error: {e}")
+        raise FileNotFoundError(f"File not found error: {e}")    
     sweep_items=get_latest_versions_of_project_sweeps(project_config)
     items=obtain_items_from_colectica(project_config["ItemTypes"], sweep_items)
     all_item_urns=[f"urn:ddi:{item['AgencyId']}:{item['Identifier']}:{item['Version']}"

--- a/src/ml_resources/data/colectica_utility.py
+++ b/src/ml_resources/data/colectica_utility.py
@@ -126,6 +126,9 @@ def get_topics_for_items(item_identifiers,
 
 def get_all_sweeps():
     start_time_for_all_sweeps_retrieval = datetime.now()
+    logger.info(StructuredMessage(message=f"Get all sweeps...",
+        operation_type="get_all_sweeps_start",
+        status="Pending"))
     sweep_info={}
     # Get all studies...
     study_items = C.search_items([C.item_code('Series')],
@@ -154,14 +157,18 @@ def get_all_sweeps():
                     sweep_info[study['AgencyId']][sweep_name]=sweep_item['Identifier']
     duration_of_all_sweeps_retrieval=datetime.now()-start_time_for_all_sweeps_retrieval
     logger.info(StructuredMessage(message=f"Time for getting all {len(study_items)} sweeps data",
-    operation_type="get_all_sweeps",
-    number_of_records=len(study_items),
-    status="Success",
-    duration=duration_of_all_sweeps_retrieval.seconds))
+        operation_type="get_all_sweeps_end",
+        number_of_records=len(study_items),
+        status="Success",
+        duration=duration_of_all_sweeps_retrieval.seconds))
     return sweep_info
 
 def get_latest_versions_of_project_sweeps(project_config):
-    start_time_for_latests_sweeps_retrieval = datetime.now()     
+    # Get the latest versions of sweeps defined in the project config...
+    start_time_for_latests_sweeps_retrieval = datetime.now()
+    logger.info(StructuredMessage(message=f"Get latest versions of sweeps...",
+        operation_type="get_latest_versions_of_project_sweeps_start",
+        status="Pending"))
     sweep_items = []
     for study, sweeps in project_config["ItemsForTrainingAndTest"]["Sweeps"].items():
         for sweep_name, sweep_id in sweeps.items():
@@ -177,7 +184,7 @@ def get_latest_versions_of_project_sweeps(project_config):
              })
     duration_of_new_sweeps_check=datetime.now()-start_time_for_latests_sweeps_retrieval
     logger.info(StructuredMessage(message=f"Time for getting latest versions of {len(sweep_items)} sweeps",
-    operation_type="get_latest_versions_of_project_sweeps",
+    operation_type="get_latest_versions_of_project_sweeps_end",
     number_of_records=len(sweep_items),
     status="Success",
     duration=duration_of_new_sweeps_check.seconds))
@@ -185,7 +192,10 @@ def get_latest_versions_of_project_sweeps(project_config):
 
 
 def obtain_items_from_colectica(item_types=[], search_set_items=[]):
-    start_time_for_items_retrieval = datetime.now()     
+    start_time_for_items_retrieval = datetime.now()   
+    logger.info(StructuredMessage(message=f"Obtain items from sweep...",
+        operation_type="obtain_items_from_colectica_end",
+        status="Pending"))  
     all_items=[]
     item_types_for_project = [C.item_code(item_type) for item_type in item_types]
     items= C.search_items(item_types_for_project,
@@ -195,7 +205,7 @@ def obtain_items_from_colectica(item_types=[], search_set_items=[]):
             SearchSets=search_set_items)['Results']
     duration_of_items_retrieval=datetime.now()-start_time_for_items_retrieval
     logger.info(StructuredMessage(message=f"Time for getting items of type {item_types}",
-    operation_type="obtain_items_from_colectica",
+    operation_type="obtain_items_from_colectica_end",
     number_of_records=len(items),
     status="Success",
     duration=duration_of_items_retrieval.seconds))


### PR DESCRIPTION
Add code that adds extra statements for defining start/end of pipeline operations. Deals with https://github.com/CLOSER-Cohorts/ml-resources/issues/121