### PR TITLE
issue-361-use-skops-to-serialise-models-and-json-for-other-data

### DIFF
--- a/projects/am2_project/am2_project.py
+++ b/projects/am2_project/am2_project.py
@@ -9,6 +9,7 @@ from src.ml_resources import (
     read_dataset_from_file,
     obtain_items_from_colectica,
     get_max_file_version,
+    get_max_folder_version,
     get_summary_data,
     get_performance_metrics)
 from projects.am2_project.src.data.utility import (
@@ -22,6 +23,7 @@ from projects.am2_project.src.evidently import (
     generate_drift_monitoring_report
 )
 from src.ml_resources.data import colectica_utility
+from skops.io import get_untrusted_types
 
 colectica_client = colectica_utility.C
 
@@ -130,6 +132,22 @@ if file_version >0:
     all_item_models=read_dataset_from_file(file_path)
 else:
     all_item_models={}
+
+folder = "./projects/am2_project/models/all_item_models_separate"
+object_name = "all_item_models_separate"
+folder_version = get_max_folder_version(Path(f"{folder}"), object_name)
+if folder_version >0:
+    folder_path = Path(f"{folder}/{object_name}_{folder_version}")
+    unknown_types = get_untrusted_types(file = folder_path / "all_models.skops")
+    if unknown_types == []:
+        all_item_models = load(folder_path / "all_models.skops", trusted=unknown_types)
+    else:
+        all_item_models={}
+
+with open(folder_path / "metadata.json") as f:
+    metadata = json.load(f)
+
+questions_model_data = pd.read_parquet(folder_path / "Question.parquet")
 
 train_semi_supervised_model(
     relationships_data_for_training_updated_model,

--- a/projects/am2_project/src/data/utility.py
+++ b/projects/am2_project/src/data/utility.py
@@ -19,6 +19,7 @@ from src.ml_resources import (
     get_max_file_version,
     get_latest_versions_of_project_sweeps,
     obtain_items_from_colectica,
+    save_versioned_model_files,
     get_all_sweeps )
 
 with open("./config/config.json") as f:
@@ -331,8 +332,8 @@ def train_semi_supervised_model(
             save_versioned_pickle_file(all_human_labelled_data.replace({np.nan: 0}),
                     "all_human_labelled_data",
                     folder='./projects/am2_project/data/human_labelled_data')
-            save_versioned_pickle_file(all_models,
-                    "all_item_models", 
+            save_versioned_model_files(all_models,
+                    "all_item_models_separate",
                     folder='./projects/am2_project/models')
             save_versioned_pickle_file(all_relationships_data,
                     'all_am2_relationships_data',

--- a/src/ml_resources/__init__.py
+++ b/src/ml_resources/__init__.py
@@ -1,5 +1,6 @@
 from .data.make_dataset import *
 from .data.pickle_utility import *
+from .data.skops_utility import *
 from .data.text_embedding_pipeline import *
 #from .features.create_text_embeddings import create_embedding_from_item
 from .models.train_model import train_model

--- a/src/ml_resources/data/skops_utility.py
+++ b/src/ml_resources/data/skops_utility.py
@@ -1,0 +1,53 @@
+from skops.io import dump
+import json
+import re
+import pandas as pd
+from pathlib import Path
+
+def get_max_folder_version(folder_path, object_name):
+    pattern = re.compile(rf"^{re.escape(object_name)}_(\d+)$")
+    max_version = 0
+    for item in folder_path.iterdir():
+        if item.is_dir():
+            match = pattern.match(item.name)
+            if match:
+                version = int(match.group(1))
+                max_version = max(max_version, version)
+    return max_version
+
+def save_versioned_model_files(model_data, object_name, folder='.'):
+    folder_path = Path(f"{folder}/{object_name}/")
+    folder_path.mkdir(parents=True, exist_ok=True)
+    # Pattern to match files like object_name_3.pickle
+    max_version=get_max_folder_version(folder_path, object_name)
+    new_version = max_version + 1
+    folder_path = Path(f"{folder}/{object_name}/{object_name}_{new_version}")
+    folder_path.mkdir(exist_ok=True)
+
+    models = {
+        item_type: model_bundle["model"]
+        for item_type, model_bundle in model_data.items()
+        }
+    models_file = folder_path / "all_models.skops"
+    dump(models, models_file)
+
+    models_metadata = {
+        item_type: model_bundle["metadata"]
+        for item_type, model_bundle in model_data.items()
+        }
+    metadata_file = folder_path / "metadata.json"
+    with open(folder_path / "metadata.json", "w", encoding="utf-8") as f:
+        json.dump(models_metadata, f, indent=4)
+
+    models_data = {
+        item_type: model_bundle["data"]
+        for item_type, model_bundle in model_data.items()
+        }
+    data_file = folder_path / "data.json"
+    for name, df in models_data.items():
+        filename = folder_path / f"{name}.parquet"
+        df.to_parquet(filename)
+    
+
+    
+    


### PR DESCRIPTION
add code that allows models, data and metadata to be saved to more secure serialisation formats (skops, parquet and json)

Deals with https://github.com/CLOSER-Cohorts/ml-resources/issues/361